### PR TITLE
Minor correction to the HandleAppendEntriesRequest state change clause

### DIFF
--- a/raft.tla
+++ b/raft.tla
@@ -369,7 +369,7 @@ HandleAppendEntriesRequest(i, j, m) ==
                                  msource         |-> i,
                                  mdest           |-> j],
                                  m)
-                       /\ UNCHANGED <<serverVars, logVars>>
+                       /\ UNCHANGED <<serverVars, log>>
                    \/ \* conflict: remove 1 entry
                        /\ m.mentries /= << >>
                        /\ Len(log[i]) >= index


### PR DESCRIPTION
For this particular case, `commitIndex` needs to change and `logVars` cannot change which is a contradiction in itself.