### PR TITLE
fix: modify the update mechanism of matchIndex and nextIndex in HandleAppendEntriesResponse to fix issue #18.

### DIFF
--- a/raft.tla
+++ b/raft.tla
@@ -393,8 +393,8 @@ HandleAppendEntriesRequest(i, j, m) ==
 HandleAppendEntriesResponse(i, j, m) ==
     /\ m.mterm = currentTerm[i]
     /\ \/ /\ m.msuccess \* successful
-          /\ nextIndex'  = [nextIndex  EXCEPT ![i][j] = m.mmatchIndex + 1]
-          /\ matchIndex' = [matchIndex EXCEPT ![i][j] = m.mmatchIndex]
+          /\ matchIndex' = [matchIndex EXCEPT ![i][j] = IF matchIndex[i][j] > m.mmatchIndex THEN matchIndex[i][j] ELSE m.mmatchIndex]
+          /\ nextIndex'  = [nextIndex  EXCEPT ![i][j] = IF matchIndex[i][j] > m.mmatchIndex THEN matchIndex[i][j] + 1 ELSE m.mmatchIndex + 1]
        \/ /\ \lnot m.msuccess \* not successful
           /\ nextIndex' = [nextIndex EXCEPT ![i][j] =
                                Max({nextIndex[i][j] - 1, 1})]


### PR DESCRIPTION
I refined the update mechanism of matchIndex and nextIndex in HandleAppendEntriesResponse to prevent updates when `matchIndex[i][j] > m.mmatchIndex`, ensuring that matchIndex and commitIndex do not decrease. For more details, see issue #18 .